### PR TITLE
Some modifications to the devise login tracker gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+*.swp
+

--- a/lib/devise/hooks/login_tracker.rb
+++ b/lib/devise/hooks/login_tracker.rb
@@ -4,14 +4,14 @@ Warden::Manager.after_authentication do |record, warden, opts|
   if record.respond_to?(:mark_login!)
     login_record = record.mark_login!(warden.request)
     scope = opts[:scope]
-    warden.session["#{scope}.login_id"] = login_record.id
+    warden.session(scope)['login_id'] = login_record.id
   end
 end
 
 Warden::Manager.before_logout do |record, warden, opts|
   if record.respond_to?(:mark_logout!)
     scope = opts[:scope]
-    login_record_id = warden.session["#{scope}.login_id"]
+    login_record_id = warden.session(scope)['login_id']
     record.mark_logout!(login_record_id) if login_record_id
   end
 end

--- a/lib/devise/models/login_tracker.rb
+++ b/lib/devise/models/login_tracker.rb
@@ -11,28 +11,20 @@ module Devise
       # to login
       # @return [UserLogin]
       def mark_login!(request)
-        login_class.create(attrs_for_login(request))
+        logins.create( ip_address: request.remote_ip,
+                      user_agent: request.user_agent,
+                      signed_in_at: Time.now
+                     )
       end
 
       # Marks the time when user has logged out on given login record ID.
       #
       # @param [Fixnum, String] login_record_id ID of login record.
       def mark_logout!(login_record_id)
-        login_record = login_class.find(login_record_id)
+        login_record = logins.find(login_record_id)
         login_record.update_column :signed_out_at, Time.now
       end
 
-      protected
-
-      def attrs_for_login(request)
-        { user_id: id, ip_address: request.remote_ip,
-          user_agent: request.user_agent,
-          signed_in_at: Time.now }
-      end
-
-      def login_class
-        "#{self.class.name}Login".safe_constantize
-      end
 
     end
   end

--- a/lib/generators/devise_login_tracker/templates/migration.rb
+++ b/lib/generators/devise_login_tracker/templates/migration.rb
@@ -3,8 +3,8 @@ class DeviseCreate<%= table_name.camelize.singularize %>Logins < ActiveRecord::M
   def up
     create_table :<%= table_name.singularize %>_logins do |t|
       t.integer  :<%= table_name.classify.foreign_key  %>
-      t.string :ip_address
-      t.string :user_agent
+      t.inet     :ip_address
+      t.string   :user_agent
       t.datetime :signed_in_at
       t.datetime :signed_out_at
     end


### PR DESCRIPTION
Hi. I've been using your gem and I've had to fix some issues that occur if you're using a model that isn't User, and possibly many Devised models in one app. In my case I have a User model and an Admin model so that I can have different authentication rules for different classes of user. It was always trying to use User, even if the login was from Admin. 

One of the changes you probably won't want to include. I've change the migration so that it uses the Postgresql type inet for storing ip addresses, hence t.inet in the migration. This is special for my use, so I'm going to change the gem to be pg-devise-login-tracker so I can publish it on RubyGems and pull it into the projects I'm working on right now. I get problems with gems loaded directly from GitHub when I'm installing in the cloud. 

Thanks for your work on this.

John Small
